### PR TITLE
Change DCMAKE_CXX_COMPILER in build instruction to clang++-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Build requirements: CMake, Clang, Vulkan SDK. (clang-cl shipped with Visual Stud
 Run requirements: Vulkan 1.3 and AVX2.
 
 ```
-cmake -S ./src -B ./build -DCMAKE_CXX_COMPILER=clang-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -S ./src -B ./build -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build ./build
 
 ./build/VoxelRT/VoxelRT.exe


### PR DESCRIPTION
Current value of DCMAKE_CXX_COMPILER is `clang-18` which causes build to throw linking errors related to C++ stuff, i.e. `std::filesystem`
```
/usr/bin/ld: ../LibHavk/libhavk.a(Pipeline.cpp.o): undefined reference to symbol '_ZNSt10filesystem8relativeERKNS_7__cxx114pathES3_@@GLIBCXX_3.4.26'
/usr/bin/ld: /lib/x86_64-linux-gnu/libstdc++.so.6: error adding symbols: DSO missing from command line
clang-18: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [VoxelRT/CMakeFiles/VoxelRT.dir/build.make:386: VoxelRT/VoxelRT] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:778: VoxelRT/CMakeFiles/VoxelRT.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

Changing that value to `clang++-18` resolves the issue.